### PR TITLE
calculatePrice in Order.java fix

### DIFF
--- a/src/Order.java
+++ b/src/Order.java
@@ -73,18 +73,72 @@ public class Order {
     public double calculatePrice(String subscription) {
         double totalPrice = 0.0;
 
+        // Calculate the total price of the cart items
         for (CartItem item : items) {
             totalPrice += item.getTotalPrice();
         }
 
-        if (subscription == "gold") {
-            totalPrice *= 0.15; // 15% discount for prime members
-        } else if (subscription == "platinum") {
-            totalPrice *= 0.10; // 10% discount for platinum members
-        } else if (subscription == "silver") {
-            totalPrice *= 0.05; // 5% discount for silver members
-        } 
+        // Get the discount using the factory and apply it
+        SubscriptionDiscount discount = SubscriptionDiscountFactory.getDiscount(subscription);
+        return discount.calculatePrice(totalPrice);
+    }
 
-        return totalPrice;
+    // Abstract class for different subscription discounts
+    abstract static class SubscriptionDiscount {
+        public abstract double calculatePrice(double totalPrice);
+    }
+
+    // Gold subscription class
+    static class GoldSubscription extends SubscriptionDiscount {
+        private static final double GOLD_DISCOUNT = 0.15;
+
+        @Override
+        public double calculatePrice(double totalPrice) {
+            return totalPrice * (1 - GOLD_DISCOUNT);  // Apply 15% discount
+        }
+    }
+
+    // Platinum subscription class
+    static class PlatinumSubscription extends SubscriptionDiscount {
+        private static final double PLATINUM_DISCOUNT = 0.10;
+
+        @Override
+        public double calculatePrice(double totalPrice) {
+            return totalPrice * (1 - PLATINUM_DISCOUNT);  // Apply 10% discount
+        }
+    }
+
+    // Silver subscription class
+    static class SilverSubscription extends SubscriptionDiscount {
+        private static final double SILVER_DISCOUNT = 0.05;
+
+        @Override
+        public double calculatePrice(double totalPrice) {
+            return totalPrice * (1 - SILVER_DISCOUNT);  // Apply 5% discount
+        }
+    }
+
+    // No subscription or invalid subscription class (no discount)
+    static class NoSubscription extends SubscriptionDiscount {
+        @Override
+        public double calculatePrice(double totalPrice) {
+            return totalPrice;  // No discount applied
+        }
+    }
+
+    // Factory class to return the appropriate discount object
+    static class SubscriptionDiscountFactory {
+        public static SubscriptionDiscount getDiscount(String subscription) {
+            switch (subscription.toLowerCase()) {
+                case "gold":
+                    return new GoldSubscription();
+                case "platinum":
+                    return new PlatinumSubscription();
+                case "silver":
+                    return new SilverSubscription();
+                default:
+                    return new NoSubscription();  // No discount for invalid subscriptions
+            }
+        }
     }
 }


### PR DESCRIPTION
I refactored the code using polymorphism, which means that different objects (like GoldSubscription, PlatinumSubscription, etc.) will each handle their own discount logic. The key benefit of this approach is that it replaces the if-else chain with more readable, scalable, and maintainable code.

Also I replaced the magic numbers with named constants like GOLD_DISCOUNT, PLATINUM_DISCOUNT, and SILVER_DISCOUNT. These are easy to modify later and make the code self-explanatory and created an abstract class SubscriptionDiscount with a method calculatePrice(). This ensures that every subscription type must implement its own logic for applying the discount.

For each subscription type (GoldSubscription, PlatinumSubscription, SilverSubscription), we created separate classes that extend the SubscriptionDiscount class. Each class implements the calculatePrice() method, applying the correct discount.
and the SubscriptionDiscountFactory is responsible for determining which discount class should be used based on the subscription type. This way, we encapsulate the decision-making process, keeping the Order class clean and focused on the price calculation.

Instead of multiplying the total price by the discount factor (which gave the wrong result), we applied the correct formula: totalPrice * (1 - DISCOUNT_RATE). This subtracts the discount from the total price, giving the correct discounted total.